### PR TITLE
Adding table-container

### DIFF
--- a/src/app/tracker/tracker.component.css
+++ b/src/app/tracker/tracker.component.css
@@ -22,6 +22,12 @@ select {
     border-radius: 25px;
 }
 
+.table-container {
+    height: 475px;
+    overflow: scroll;
+    margin-bottom: 100px;
+}
+
 .table th {
     font-family: 'regular';
     color: rgb(0, 0, 0);

--- a/src/app/tracker/tracker.component.html
+++ b/src/app/tracker/tracker.component.html
@@ -60,28 +60,30 @@
 </div>
 
 <!-- table ------------- -->
-<div class="container-fluid ">
-    <div class="row d-flex justify-content-center">
+<div class="table-container">
+    <div class="container-fluid ">
+        <div class="row d-flex justify-content-center">
 
-        <div class="col-sm-5  col-md-5 col-lg-12">
+            <div class="col-sm-5  col-md-5 col-lg-12">
 
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th>Sno.</th>
-                        <th>Date</th>
-                        <th>Cases</th>
-                    </tr>
-                </thead>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Sno.</th>
+                            <th>Date</th>
+                            <th>Cases</th>
+                        </tr>
+                    </thead>
 
-                <tbody>
-                    <tr *ngFor='let cs of selectedCountryData; index as i '>
-                        <td>{{i+1}}</td>
-                        <td>{{cs.date | date}}</td>
-                        <td>{{cs.cases}}</td>
-                    </tr>
-                </tbody>
-            </table>
+                    <tbody>
+                        <tr *ngFor='let cs of selectedCountryData; index as i '>
+                            <td>{{i+1}}</td>
+                            <td>{{cs.date | date}}</td>
+                            <td>{{cs.cases}}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
The table displayed at /Covinex/tracker i.e at "Country Tracker" has 489 rows.  That's a hell of a lot number of rows and provides a bad user experience. I have added a table-container class and some styles to display only 10 rows at a time. The user can then scroll down to see more rows.
![image](https://user-images.githubusercontent.com/51775341/119600843-84611180-be05-11eb-9901-286e073cb7b1.png)

It provides a lot better user experience.